### PR TITLE
PlexClient: Catch bad credentials exception.

### DIFF
--- a/plex_manager/plex_client.py
+++ b/plex_manager/plex_client.py
@@ -1,4 +1,5 @@
 from plexapi.server import PlexServer
+from plexapi.exceptions import BadRequest
 from requests.exceptions import ConnectionError
 
 from vestibule_configurations.models import VestibuleConfiguration
@@ -31,7 +32,7 @@ class PlexClient:
         try:
             PlexServer(baseurl=self._base_url, token=self._token)
             return True
-        except ConnectionError as e:
+        except (ConnectionError, BadRequest) as e:
             print(f"Plex is down - {e}")
             return False
 


### PR DESCRIPTION
Currently with wrong plex token the exception is not catched and is raised instead of returning False, so the icon remain grey instead of turning red, this fixes it.